### PR TITLE
Set the __scheme__ value based on port being 443

### DIFF
--- a/discoverecs.py
+++ b/discoverecs.py
@@ -362,6 +362,9 @@ class Main:
             jobs[i] = []
         log('Targets: ' + str(len(targets)))
         for target in targets:
+            scheme = "http"
+            if(target.port.endswith('443')):
+                scheme = "https"
             path_interval = extract_path_interval(target.metrics_path)
             for path, interval in path_interval.items():
                 labels = False
@@ -384,7 +387,8 @@ class Main:
                     'labels' : {
                         'instance': target.p_instance,
                         'job' : target.ecs_task_name,
-                        'metrics_path' : path
+                        'metrics_path' : path,
+                        '__scheme__': scheme
                     }
                 }
                 if labels:

--- a/discoverecs.py
+++ b/discoverecs.py
@@ -255,8 +255,8 @@ def get_environment_var(environment, name):
             return entry['value']
     return None
 
-def extract_task_id(arn):
-    return arn.split(":")[5].split('/')[2]
+def extract_arn_id(arn, index):
+    return arn.split(":")[5].split('/')[index]
 
 def extract_name(arn):
     return arn.split(":")[5].split('/')[1]
@@ -314,14 +314,14 @@ def task_info_to_targets(task_info):
                     ecs_task_id = ecs_task_version = ecs_container_id = ecs_cluster_name = ec2_instance_id = None
                 else:
                     p_instance = interface_ip + ':' + first_port
-                    ecs_task_id=extract_task_id(task_info.task['taskArn'])
+                    ecs_task_id=extract_arn_id(task_info.task['taskArn'], 2)
                     ecs_task_version=extract_task_version(task_info.task['taskDefinitionArn'])
                     ecs_cluster_name=extract_name(task_info.task['clusterArn'])
                     if 'FARGATE' in task_info.task_definition.get('requiresCompatibilities', ''):
                         ec2_instance_id = ecs_container_id = None
                     else:
                         ec2_instance_id=task_info.container_instance['ec2InstanceId']
-                        ecs_container_id=extract_name(container['containerArn'])
+                        ecs_container_id=extract_arn_id(container['containerArn'], 2)
 
                 return [Target(
                     ip=interface_ip,

--- a/discoverecs.py
+++ b/discoverecs.py
@@ -255,6 +255,9 @@ def get_environment_var(environment, name):
             return entry['value']
     return None
 
+def extract_task_id(arn):
+    return arn.split(":")[5].split('/')[2]
+
 def extract_name(arn):
     return arn.split(":")[5].split('/')[1]
 
@@ -311,7 +314,7 @@ def task_info_to_targets(task_info):
                     ecs_task_id = ecs_task_version = ecs_container_id = ecs_cluster_name = ec2_instance_id = None
                 else:
                     p_instance = interface_ip + ':' + first_port
-                    ecs_task_id=extract_name(task_info.task['taskArn'])
+                    ecs_task_id=extract_task_id(task_info.task['taskArn'])
                     ecs_task_version=extract_task_version(task_info.task['taskDefinitionArn'])
                     ecs_cluster_name=extract_name(task_info.task['clusterArn'])
                     if 'FARGATE' in task_info.task_definition.get('requiresCompatibilities', ''):


### PR DESCRIPTION
If the port name is not defined, then prometheus will guess the port based on the scheme's default, but there was no way to say that if port is 443 then scheme should be httpe, other than setting in prometheus.yml that all targets for this discovery use the same scheme

https://www.robustperception.io/life-of-a-label